### PR TITLE
Add a basic UI for excluding specific apps from being hooked

### DIFF
--- a/SSLKillSwitch/SSLKillSwitch.m
+++ b/SSLKillSwitch/SSLKillSwitch.m
@@ -50,6 +50,21 @@ static BOOL shouldHookFromPreference(NSString *preferenceSetting)
     {
         shouldHook = [[plist objectForKey:preferenceSetting] boolValue];
         SSKLog(@"Preference set to %d.", shouldHook);
+
+        // Checking if BundleId has been excluded by user
+        NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
+        bundleId = [bundleId stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+        NSString *excludedBundleIdsString = [plist objectForKey:@"excludedBundleIds"];
+        excludedBundleIdsString = [excludedBundleIdsString stringByReplacingOccurrencesOfString:@" " withString:@""];
+
+        NSArray *excludedBundleIds = [excludedBundleIdsString componentsSeparatedByString:@","];
+
+        if ([excludedBundleIds containsObject:bundleId])
+        {
+            SSKLog(@"Not hooking excluded bundle: %@", bundleId);
+            shouldHook = NO;
+        }
     }
     return shouldHook;
 }

--- a/layout/Library/PreferenceLoader/Preferences/SSLKillSwitch_prefs.plist
+++ b/layout/Library/PreferenceLoader/Preferences/SSLKillSwitch_prefs.plist
@@ -33,6 +33,22 @@
 			<key>label</key>
 			<string>Disable Certificate Validation</string>
 		</dict>
+		<dict>
+                        <key>cell</key>
+                        <string>PSEditTextCell</string>
+                        <key>label</key>
+                        <string>Excluded BundleIDs:</string>
+                        <key>key</key>
+                        <string>excludedBundleIds</string>
+                        <key>default</key>
+                        <string></string>
+                        <key>defaults</key>
+                        <string>com.nablac0d3.SSLKillSwitchSettings</string>
+                        <key>keyboard</key>
+                        <string></string>
+                        <key>noAutoCorrect</key>
+                        <true/>
+                </dict>
 	</array>
 	<key>title</key>
 	<string>SSL Kill Switch 2</string>


### PR DESCRIPTION
While filtering the process the tweak is injected in using SSLKillSwitch2.plist is possible, it only allows you to add bundles it should inject into, not ones to exclude. In other words, you'd have to remove the very general rules used by default and then manually specify every single app to inject into. This pull request adds a way to explicitly include certain apps (bundleIds) instead.

Note that the UI is rudimentary at best, but it gets the job done
for now.