### PR TITLE
update documentation for iOS 14 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ There are several ways to do this including:
 
   If you receive a zero pointer then you may need to enable code-signing and build for profiling then use the binary in the release folder, and even may have to copy the binary to the app's resources folder. In which case you would have seen a sandbox read violation output to console. To test a new version of the binary you need to kill the app and load it in again.
 
-* Using DYLD\_INSERT\_LIBRARIES to inject SSLKillSwitch and start the process.
+* Using `DYLD_INSERT_LIBRARIES` to inject SSLKillSwitch and start the process.
 
 ### Restricted Apps
 
@@ -144,7 +144,7 @@ Changelog
 License
 -------
 
-MIT - See ./LICENSE.
+MIT - See [LICENSE](./LICENSE).
 
 Author
 ------

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ that you need to inject in the process where you want to disable SSL pinning.
 Changelog
 ---------
 
-* v0.14: Added support for iOS 13.
+* v0.14: Added support for iOS 13 & 14.
 * v0.13: Added support for iOS 12.
 * v0.12: Added support for iOS 11.
 * v0.11: Added support for iOS 10.

--- a/SSLKillSwitch/SSLKillSwitch.m
+++ b/SSLKillSwitch/SSLKillSwitch.m
@@ -229,8 +229,8 @@ __attribute__((constructor)) static void init(int argc, const char **argv)
 
             if ([processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){13, 0, 0}])
             {
-                SSKLog(@"iOS 13 detected");
-                // iOS 13 uses SSL_set_custom_verify() which was recently added to BoringSSL
+                SSKLog(@"iOS 13+ detected");
+                // Both iOS 13 & 14 use SSL_set_custom_verify() which was recently added to BoringSSL
                 void *SSL_set_custom_verify = dlsym(boringssl_handle, "SSL_set_custom_verify");
                 if (SSL_set_custom_verify)
                 {


### PR DESCRIPTION
I've tested it on iOS 14.0, 14.1 and 14.2 and it works splendidly :)
Just updated the strings to let everyone know it still works